### PR TITLE
Add LangChain EspoCRM integration example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,42 @@
+# LangChain + EspoCRM Example
+
+This directory contains `langchain_espo_agent.py`, an example showing how to wrap the delegation flow from this repository into a LangChain agent that queries an EspoCRM API.
+
+## Requirements
+
+- Python 3.8+
+- Packages from `requirements.txt`
+- `langchain` and `openai`
+- Access to an EspoCRM instance and API key
+
+## Running the Example
+
+1. Install dependencies:
+
+```bash
+pip install -r ../requirements.txt
+pip install langchain openai
+```
+
+2. Start the Authorization and Resource servers in separate terminals:
+
+```bash
+python ../auth_server.py
+python ../resource_server.py
+```
+
+3. Set your OpenAI API key (required by LangChain's default LLM):
+
+```bash
+export OPENAI_API_KEY=<your-openai-key>
+```
+
+4. Update `ESPOCRM_BASE` and the `EspoCRM-Api-Key` placeholder in `langchain_espo_agent.py` with your EspoCRM details.
+
+5. Run the agent:
+
+```bash
+python langchain_espo_agent.py
+```
+
+The script requests a delegation token, exchanges it for an access token, and then calls the specified EspoCRM endpoint using that token.

--- a/examples/langchain_espo_agent.py
+++ b/examples/langchain_espo_agent.py
@@ -1,0 +1,48 @@
+"""LangChain agent example integrating the delegation protocol with an EspoCRM API."""
+from langchain.agents import Tool, initialize_agent
+from langchain.llms import OpenAI
+import requests
+
+AUTH_URL = "http://localhost:5000"
+RESOURCE_URL = "http://localhost:6000/data"
+ESPOCRM_BASE = "https://your-espocrm.example/api/v1"  # Replace with your EspoCRM URL
+
+
+def fetch_access_token(scope: str = "crm:read") -> str:
+    """Obtain an access token via the delegation flow."""
+    res = requests.get(
+        f"{AUTH_URL}/authorize",
+        params={"user": "alice", "client_id": "agent-client-id", "scope": scope},
+    )
+    res.raise_for_status()
+    delegation_token = res.json()["delegation_token"]
+
+    res = requests.post(f"{AUTH_URL}/token", data={"delegation_token": delegation_token})
+    res.raise_for_status()
+    return res.json()["access_token"]
+
+
+def query_espocrm(endpoint: str) -> dict:
+    """Call an EspoCRM endpoint using a delegated access token."""
+    token = fetch_access_token()
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "EspoCRM-Api-Key": "<espocrm_api_key>",  # TODO: replace with your key
+    }
+    resp = requests.get(f"{ESPOCRM_BASE}/{endpoint}", headers=headers)
+    resp.raise_for_status()
+    return resp.json()
+
+
+espocrm_tool = Tool(
+    name="EspoCRM lookup",
+    func=lambda text: query_espocrm(text),
+    description="Access EspoCRM with delegated authority",
+)
+
+
+llm = OpenAI(temperature=0)
+agent = initialize_agent([espocrm_tool], llm=llm, agent="zero-shot-react-description")
+
+if __name__ == "__main__":
+    print(agent.run("lookup Accounts/1234"))


### PR DESCRIPTION
## Summary
- add `examples/langchain_espo_agent.py` demonstrating how to use the delegation flow from this repo inside a LangChain tool
- provide `examples/README.md` with setup instructions for integrating with EspoCRM

## Testing
- `python -m py_compile ai_agent.py auth_server.py resource_server.py examples/langchain_espo_agent.py`

------
