### PR TITLE
Add EspoCRM github workflow

### DIFF
--- a/.github/workflows/espocrm.yml
+++ b/.github/workflows/espocrm.yml
@@ -1,0 +1,28 @@
+# yamllint disable rule:line-length rule:truthy
+---
+name: espocrm-test
+on:
+  - push
+  - pull_request
+jobs:
+  espocrm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Start MariaDB
+        run: |
+          docker run -d --name mariadb -e MARIADB_ROOT_PASSWORD=password mariadb:latest
+      - name: Start EspoCRM
+        run: |
+          docker run -d --name espocrm --link mariadb:mariadb -p 8080:80 espocrm/espocrm:latest
+      - name: Wait for EspoCRM
+        run: |
+          for i in {1..60}; do
+            if curl -s http://localhost:8080 > /dev/null; then
+              break
+            fi
+            sleep 5
+          done
+      - name: Smoke test
+        run: |
+          curl -fsS http://localhost:8080/


### PR DESCRIPTION
## Summary
- add workflow to deploy EspoCRM and MariaDB in Docker

## Testing
- `yamllint .github/workflows/espocrm.yml`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849ee5987788324ba0bd2c79489ac9c