### PR TITLE
Add Docker-based test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build and start containers
+        run: |
+          docker-compose up -d --build
+          sleep 10
+
+      - name: Run tests
+        run: pytest --junitxml=test-results.xml
+
+      - name: Stop containers
+        if: always()
+        run: docker-compose down
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: test-results.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: test-results.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+CMD ["python"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  auth_server:
+    build: .
+    command: python auth_server.py
+    ports:
+      - "5000:5000"
+  resource_server:
+    build: .
+    command: python resource_server.py
+    depends_on:
+      - auth_server
+    environment:
+      INTROSPECT_URL: http://auth_server:5000/introspect
+    ports:
+      - "6000:6000"

--- a/resource_server.py
+++ b/resource_server.py
@@ -3,9 +3,10 @@ from flask import Flask, request, jsonify
 import jwt
 from datetime import datetime
 import requests
+import os
 
 app = Flask(__name__)
-INTROSPECT_URL = "http://localhost:5000/introspect"
+INTROSPECT_URL = os.getenv("INTROSPECT_URL", "http://localhost:5000/introspect")
 
 @app.route('/data')
 def data():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,39 @@
+import time
+import requests
+
+BASE_AUTH = 'http://localhost:5000'
+BASE_RESOURCE = 'http://localhost:6000'
+
+def wait_for(url, timeout=15):
+    end = time.time() + timeout
+    while time.time() < end:
+        try:
+            r = requests.get(url)
+            if r.status_code < 500:
+                return True
+        except Exception:
+            pass
+        time.sleep(1)
+    return False
+
+def test_delegation_flow():
+    assert wait_for(f"{BASE_AUTH}/authorize")
+
+    r = requests.get(f"{BASE_AUTH}/authorize", params={
+        'user': 'alice',
+        'client_id': 'agent-client-id',
+        'scope': 'read:data'
+    })
+    assert r.status_code == 200
+    delegation = r.json()['delegation_token']
+
+    r = requests.post(f"{BASE_AUTH}/token", data={'delegation_token': delegation})
+    assert r.status_code == 200
+    token = r.json()['access_token']
+
+    headers = {'Authorization': f'Bearer {token}'}
+    r = requests.get(f"{BASE_RESOURCE}/data", headers=headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data['user'] == 'alice'
+    assert data['agent'] == 'agent-client-id'


### PR DESCRIPTION
## Summary
- add Dockerfile and docker-compose for running the servers
- add integration test of delegation flow
- configure GitHub Actions workflow to run tests inside Docker containers
- allow resource server to read `INTROSPECT_URL` from env

## Testing
- `pytest -q` *(fails: token check before docker containers start)*

------
https://chatgpt.com/codex/tasks/task_e_684a7d82372c8324a8a7185701c5b979