### PR TITLE
Add pytest integration tests and GitHub workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.11
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Flask==2.3.3
 PyJWT==2.8.0
 requests==2.32.2
+
+pytest==8.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import os, sys
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+import auth_server
+import resource_server
+from tests.utils import start_server
+
+@pytest.fixture(scope='session', autouse=True)
+def servers():
+    # start auth and resource servers for tests
+    auth_srv = start_server(auth_server.app, port=5000)
+    res_srv = start_server(resource_server.app, port=6000)
+    yield
+    res_srv.shutdown()
+    auth_srv.shutdown()
+
+@pytest.fixture(autouse=True)
+def reset_state():
+    auth_server.ACTIVE_TOKENS.clear()
+    auth_server.REVOKED_TOKENS.clear()

--- a/tests/test_delegation_flow.py
+++ b/tests/test_delegation_flow.py
@@ -1,0 +1,24 @@
+import requests
+
+BASE_AUTH = 'http://localhost:5000'
+BASE_RS = 'http://localhost:6000'
+
+def test_full_delegation_flow():
+    r = requests.get(f'{BASE_AUTH}/authorize', params={
+        'user': 'alice',
+        'client_id': 'agent-client-id',
+        'scope': 'read:data'
+    })
+    assert r.status_code == 200
+    delegation = r.json()['delegation_token']
+
+    r = requests.post(f'{BASE_AUTH}/token', data={'delegation_token': delegation})
+    assert r.status_code == 200
+    access_token = r.json()['access_token']
+
+    headers = {'Authorization': f'Bearer {access_token}'}
+    r = requests.get(f'{BASE_RS}/data', headers=headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body['user'] == 'alice'
+    assert body['agent'] == 'agent-client-id'

--- a/tests/test_revocation.py
+++ b/tests/test_revocation.py
@@ -1,0 +1,26 @@
+import requests
+
+BASE_AUTH = 'http://localhost:5000'
+BASE_RS = 'http://localhost:6000'
+
+def _get_access_token():
+    r = requests.get(f'{BASE_AUTH}/authorize', params={
+        'user': 'alice',
+        'client_id': 'agent-client-id',
+        'scope': 'read:data'
+    })
+    delegation = r.json()['delegation_token']
+    r = requests.post(f'{BASE_AUTH}/token', data={'delegation_token': delegation})
+    return r.json()['access_token']
+
+def test_revoked_token_rejected():
+    token = _get_access_token()
+    headers = {'Authorization': f'Bearer {token}'}
+    r = requests.get(f'{BASE_RS}/data', headers=headers)
+    assert r.status_code == 200
+
+    r = requests.post(f'{BASE_AUTH}/revoke', data={'token': token})
+    assert r.status_code == 200
+
+    r = requests.get(f'{BASE_RS}/data', headers=headers)
+    assert r.status_code == 403

--- a/tests/test_token_issuance.py
+++ b/tests/test_token_issuance.py
@@ -1,0 +1,35 @@
+import jwt
+import requests
+import auth_server
+
+JWT_SECRET = auth_server.JWT_SECRET
+BASE_URL = 'http://localhost:5000'
+
+def test_authorize_returns_delegation_token():
+    resp = requests.get(f'{BASE_URL}/authorize', params={
+        'user': 'alice',
+        'client_id': 'agent-client-id',
+        'scope': 'read:data write:data'
+    })
+    assert resp.status_code == 200
+    token = resp.json()['delegation_token']
+    decoded = jwt.decode(token, JWT_SECRET, algorithms=['HS256'])
+    assert decoded['sub'] == 'agent-client-id'
+    assert decoded['delegator'] == 'alice'
+
+
+def test_token_exchange_returns_access_token():
+    # obtain delegation token first
+    r = requests.get(f'{BASE_URL}/authorize', params={
+        'user': 'alice',
+        'client_id': 'agent-client-id',
+        'scope': 'read:data'
+    })
+    delegation_token = r.json()['delegation_token']
+
+    r = requests.post(f'{BASE_URL}/token', data={'delegation_token': delegation_token})
+    assert r.status_code == 200
+    access_token = r.json()['access_token']
+    decoded = jwt.decode(access_token, JWT_SECRET, algorithms=['HS256'])
+    assert decoded['sub'] == 'alice'
+    assert decoded['actor'] == 'agent-client-id'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,24 @@
+import threading
+import time
+from werkzeug.serving import make_server
+
+class ServerThread(threading.Thread):
+    def __init__(self, app, host='localhost', port=0):
+        super().__init__()
+        self.server = make_server(host, port, app)
+        self.port = self.server.server_port
+        self.daemon = True
+
+    def run(self):
+        self.server.serve_forever()
+
+    def shutdown(self):
+        self.server.shutdown()
+        self.join()
+
+def start_server(app, port):
+    server = ServerThread(app, port=port)
+    server.start()
+    # Wait briefly for server to start
+    time.sleep(0.2)
+    return server


### PR DESCRIPTION
## Summary
- add PyTest-based test suite covering token issuance, delegation flow, and revocation
- run Flask apps in background threads for tests
- introduce GitHub Actions workflow using a Python Docker container
- include pytest in requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a7d7ca7c08324a5cb903e1758bc13