### PR TITLE
Add Docker Compose to test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,15 @@ jobs:
       image: python:3.11
     steps:
       - uses: actions/checkout@v3
+      - name: Install Docker Compose
+        run: |
+          apt-get update
+          apt-get install -y docker-compose-plugin
+      - name: Start services
+        run: docker compose up -d
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
           pip install pytest
       - name: Run tests
-        run: pytest -v
+        run: USE_COMPOSE_SERVICES=1 pytest -v

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3'
+services:
+  auth:
+    image: python:3.11
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: sh -c "pip install -r requirements.txt && python auth_server.py"
+    ports:
+      - "5000:5000"
+  resource:
+    image: python:3.11
+    working_dir: /app
+    volumes:
+      - .:/app
+    command: sh -c "pip install -r requirements.txt && python resource_server.py"
+    ports:
+      - "6000:6000"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,12 @@ from tests.utils import start_server
 
 @pytest.fixture(scope='session', autouse=True)
 def servers():
-    # start auth and resource servers for tests
+    """Start auth and resource servers unless using external services."""
+    if os.getenv("USE_COMPOSE_SERVICES"):
+        # Services assumed to be started externally, e.g. via docker compose
+        yield
+        return
+
     auth_srv = start_server(auth_server.app, port=5000)
     res_srv = start_server(resource_server.app, port=6000)
     yield


### PR DESCRIPTION
## Summary
- add a Docker Compose file for running auth and resource servers
- skip starting servers in tests when services are already running
- update GitHub Actions workflow to install Docker Compose, start services, and run tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a81b1884883248865aa092ee7008e