### PR TITLE
Add agent registration endpoint and tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,6 +9,9 @@ jobs:
       image: python:3.11
     steps:
       - uses: actions/checkout@v3
+      - name: Initialize sample agent data
+        run: |
+          echo '{"agent-client-id": {"name": "CalendarAgent"}}' > agents.json
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/agents.json
+++ b/agents.json
@@ -1,0 +1,1 @@
+{"agent-client-id": {"name": "CalendarAgent"}}

--- a/auth_server.py
+++ b/auth_server.py
@@ -2,13 +2,45 @@
 from flask import Flask, request, jsonify
 from datetime import datetime, timedelta
 import jwt
+import json
+import os
 
 app = Flask(__name__)
 JWT_SECRET = 'jwt-signing-secret'
-AGENTS = {"agent-client-id": {"name": "CalendarAgent"}}
+AGENTS_FILE = os.environ.get("AGENTS_FILE", "agents.json")
+
+
+def load_agents():
+    if os.path.exists(AGENTS_FILE):
+        with open(AGENTS_FILE) as f:
+            return json.load(f)
+    return {}
+
+
+def save_agents(data):
+    with open(AGENTS_FILE, "w") as f:
+        json.dump(data, f)
+
+
+AGENTS = load_agents()
 USERS = {"alice": "password123"}
 ACTIVE_TOKENS = []
 REVOKED_TOKENS = set()
+
+
+@app.route('/register', methods=['POST'])
+def register():
+    data = request.get_json(force=True, silent=True) or {}
+    client_id = data.get('client_id')
+    name = data.get('name')
+    if not client_id or not name:
+        return jsonify({'error': 'missing client_id or name'}), 400
+    if client_id in AGENTS:
+        return jsonify({'error': 'client exists'}), 400
+
+    AGENTS[client_id] = {'name': name}
+    save_agents(AGENTS)
+    return jsonify({'status': 'registered'}), 201
 
 @app.route('/authorize')
 def authorize():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,3 +18,5 @@ def servers():
 def reset_state():
     auth_server.ACTIVE_TOKENS.clear()
     auth_server.REVOKED_TOKENS.clear()
+    # reload agents from persistent file to ensure isolation
+    auth_server.AGENTS = auth_server.load_agents()

--- a/tests/test_client_registration.py
+++ b/tests/test_client_registration.py
@@ -1,0 +1,36 @@
+import requests
+
+BASE_URL = 'http://localhost:5000'
+
+
+def test_register_new_client():
+    resp = requests.post(f'{BASE_URL}/register', json={
+        'client_id': 'test-agent',
+        'name': 'TestAgent'
+    })
+    assert resp.status_code == 201
+
+    # Newly registered agent should be authorized
+    r = requests.get(f'{BASE_URL}/authorize', params={
+        'user': 'alice',
+        'client_id': 'test-agent',
+        'scope': 'read:data'
+    })
+    assert r.status_code == 200
+
+
+def test_register_duplicate_client_fails():
+    resp = requests.post(f'{BASE_URL}/register', json={
+        'client_id': 'agent-client-id',
+        'name': 'CalendarAgent'
+    })
+    assert resp.status_code == 400
+
+
+def test_authorize_unregistered_client_fails():
+    r = requests.get(f'{BASE_URL}/authorize', params={
+        'user': 'alice',
+        'client_id': 'unknown-agent',
+        'scope': 'read:data'
+    })
+    assert r.status_code == 403


### PR DESCRIPTION
## Summary
- add persistent agent registration to `auth_server`
- check registered agents during authorization
- create registration tests
- load agent data in tests to ensure isolation
- initialize sample agent file in GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8aae96fc8324b452d97acccc35b7