### PR TITLE
Use temp agents file for tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: python:3.11
+    env:
+      AGENTS_FILE: /tmp/agents.json
     steps:
       - uses: actions/checkout@v3
       - name: Initialize sample agent data
         run: |
-          echo '{"agent-client-id": {"name": "CalendarAgent"}}' > agents.json
+          echo '{"agent-client-id": {"name": "CalendarAgent"}}' > "$AGENTS_FILE"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,17 @@
-import os, sys
+import os
+import sys
+import json
+import tempfile
+
+# Create a temporary agents file and set the environment variable BEFORE
+# importing the auth_server module so that it loads the correct file.
+temp_agents_file = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+json.dump({"agent-client-id": {"name": "CalendarAgent"}}, temp_agents_file)
+temp_agents_file.close()
+os.environ["AGENTS_FILE"] = temp_agents_file.name
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 import pytest
 import auth_server
 import resource_server
@@ -13,6 +25,7 @@ def servers():
     yield
     res_srv.shutdown()
     auth_srv.shutdown()
+    os.remove(temp_agents_file.name)
 
 @pytest.fixture(autouse=True)
 def reset_state():


### PR DESCRIPTION
## Summary
- create a temp `agents.json` path in `tests/conftest.py` before importing `auth_server`
- clean up the file after shutting servers down
- reference the temp file in the tests workflow instead of writing into the repo

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8e76fb8c8324a61c24bbf8e5775d