### PR TITLE
Remove redundant pytest install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,5 @@ jobs:
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
-          pip install pytest
       - name: Run tests
         run: pytest -v


### PR DESCRIPTION
## Summary
- cleanup CI workflow by removing extra `pip install pytest`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684a8e817e40832482f0c5a8be3955f2