### PR TITLE
Implement PKCE and DPoP enforcement

### DIFF
--- a/ai_agent.py
+++ b/ai_agent.py
@@ -1,24 +1,69 @@
 # === File: ai_agent.py ===
 import requests
+import secrets
+import hashlib
+import base64
+import time
+import uuid
+import json
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives import serialization
+from jwt import algorithms
+import jwt
 
-print("=== STEP 1: Requesting Delegation Token ===")
-res = requests.get("http://localhost:5000/authorize", params={
-    "user": "alice",
-    "client_id": "agent-client-id",
-    "scope": "read:data write:data"
-})
+# PKCE setup
+code_verifier = secrets.token_urlsafe(32)
+code_challenge = base64.urlsafe_b64encode(
+    hashlib.sha256(code_verifier.encode()).digest()
+).decode().rstrip("=")
+
+print("=== STEP 1: Requesting Delegation Token with PKCE ===")
+res = requests.get(
+    "http://localhost:5000/authorize",
+    params={
+        "user": "alice",
+        "client_id": "agent-client-id",
+        "scope": "read:data write:data",
+        "code_challenge": code_challenge,
+        "code_challenge_method": "S256",
+    },
+)
 delegation_token = res.json()["delegation_token"]
 print("Delegation Token Received\n")
 
 print("=== STEP 2: Exchanging for Access Token ===")
-res = requests.post("http://localhost:5000/token", data={
-    "delegation_token": delegation_token
-})
+res = requests.post(
+    "http://localhost:5000/token",
+    data={"delegation_token": delegation_token, "code_verifier": code_verifier},
+)
 access_token = res.json()["access_token"]
 print("Access Token Received\n")
 
-print("=== STEP 3: Accessing Protected Resource ===")
-headers = {"Authorization": f"Bearer {access_token}"}
+print("=== STEP 3: Accessing Protected Resource with DPoP ===")
+
+# Generate ephemeral key for DPoP
+private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+public_jwk = json.loads(algorithms.RSAAlgorithm.to_jwk(private_key.public_key()))
+
+def create_dpop_proof(url, method):
+    payload = {
+        "htu": url,
+        "htm": method,
+        "iat": int(time.time()),
+        "jti": str(uuid.uuid4()),
+    }
+    return jwt.encode(
+        payload,
+        private_key,
+        algorithm="RS256",
+        headers={"jwk": public_jwk, "typ": "dpop+jwt"},
+    )
+
+proof = create_dpop_proof("http://localhost:6000/data", "GET")
+headers = {
+    "Authorization": f"Bearer {access_token}",
+    "DPoP": proof,
+}
 res = requests.get("http://localhost:6000/data", headers=headers)
 print("Response:", res.json())
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask==2.3.3
 PyJWT==2.8.0
 requests==2.32.2
+cryptography==42.0.5
 
 pytest==8.2.0

--- a/resource_server.py
+++ b/resource_server.py
@@ -1,18 +1,46 @@
 # === File: resource_server.py ===
 from flask import Flask, request, jsonify
 import jwt
+from jwt import algorithms
 from datetime import datetime
 import requests
+import json
+import time
 
 app = Flask(__name__)
 INTROSPECT_URL = "http://localhost:5000/introspect"
+DPOP_JTIS = set()
 
 @app.route('/data')
 def data():
     auth = request.headers.get("Authorization")
+    dpop = request.headers.get("DPoP")
     if not auth or not auth.startswith("Bearer "):
         return "Missing Authorization header", 401
+    if not dpop:
+        return "Missing DPoP header", 401
+
     token = auth.split()[1]
+
+    # Validate DPoP proof
+    try:
+        header = jwt.get_unverified_header(dpop)
+        jwk = header.get("jwk")
+        key = algorithms.RSAAlgorithm.from_jwk(json.dumps(jwk))
+        payload = jwt.decode(dpop, key=key, algorithms=["RS256"])
+    except Exception:
+        return "Invalid DPoP proof", 401
+
+    if payload.get("htm") != request.method:
+        return "DPoP htm mismatch", 401
+    if payload.get("htu") != request.base_url:
+        return "DPoP htu mismatch", 401
+    if abs(time.time() - payload.get("iat", 0)) > 300:
+        return "DPoP iat expired", 401
+    jti = payload.get("jti")
+    if jti in DPOP_JTIS:
+        return "DPoP replay", 401
+    DPOP_JTIS.add(jti)
 
     r = requests.post(INTROSPECT_URL, data={"token": token})
     result = r.json()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import pytest
 import auth_server
 import resource_server
-from tests.utils import start_server
+from tests.utils import start_server, DPoPKey
 
 @pytest.fixture(scope='session', autouse=True)
 def servers():
@@ -18,3 +18,8 @@ def servers():
 def reset_state():
     auth_server.ACTIVE_TOKENS.clear()
     auth_server.REVOKED_TOKENS.clear()
+
+
+@pytest.fixture(scope="session")
+def dpop_key():
+    return DPoPKey()

--- a/tests/test_delegation_flow.py
+++ b/tests/test_delegation_flow.py
@@ -1,22 +1,33 @@
 import requests
+from tests.utils import generate_pkce_pair
 
 BASE_AUTH = 'http://localhost:5000'
 BASE_RS = 'http://localhost:6000'
 
-def test_full_delegation_flow():
-    r = requests.get(f'{BASE_AUTH}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data'
-    })
+def test_full_delegation_flow(dpop_key):
+    verifier, challenge = generate_pkce_pair()
+    r = requests.get(
+        f'{BASE_AUTH}/authorize',
+        params={
+            'user': 'alice',
+            'client_id': 'agent-client-id',
+            'scope': 'read:data',
+            'code_challenge': challenge,
+            'code_challenge_method': 'S256',
+        },
+    )
     assert r.status_code == 200
     delegation = r.json()['delegation_token']
 
-    r = requests.post(f'{BASE_AUTH}/token', data={'delegation_token': delegation})
+    r = requests.post(
+        f'{BASE_AUTH}/token',
+        data={'delegation_token': delegation, 'code_verifier': verifier},
+    )
     assert r.status_code == 200
     access_token = r.json()['access_token']
 
-    headers = {'Authorization': f'Bearer {access_token}'}
+    proof = dpop_key.proof(f'{BASE_RS}/data', 'GET')
+    headers = {'Authorization': f'Bearer {access_token}', 'DPoP': proof}
     r = requests.get(f'{BASE_RS}/data', headers=headers)
     assert r.status_code == 200
     body = r.json()

--- a/tests/test_revocation.py
+++ b/tests/test_revocation.py
@@ -1,26 +1,40 @@
 import requests
+from tests.utils import generate_pkce_pair
 
 BASE_AUTH = 'http://localhost:5000'
 BASE_RS = 'http://localhost:6000'
 
 def _get_access_token():
-    r = requests.get(f'{BASE_AUTH}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data'
-    })
+    verifier, challenge = generate_pkce_pair()
+    r = requests.get(
+        f'{BASE_AUTH}/authorize',
+        params={
+            'user': 'alice',
+            'client_id': 'agent-client-id',
+            'scope': 'read:data',
+            'code_challenge': challenge,
+            'code_challenge_method': 'S256',
+        },
+    )
     delegation = r.json()['delegation_token']
-    r = requests.post(f'{BASE_AUTH}/token', data={'delegation_token': delegation})
+    r = requests.post(
+        f'{BASE_AUTH}/token',
+        data={'delegation_token': delegation, 'code_verifier': verifier},
+    )
     return r.json()['access_token']
 
-def test_revoked_token_rejected():
+def test_revoked_token_rejected(dpop_key):
     token = _get_access_token()
-    headers = {'Authorization': f'Bearer {token}'}
+    headers = {
+        'Authorization': f'Bearer {token}',
+        'DPoP': dpop_key.proof(f'{BASE_RS}/data', 'GET')
+    }
     r = requests.get(f'{BASE_RS}/data', headers=headers)
     assert r.status_code == 200
 
     r = requests.post(f'{BASE_AUTH}/revoke', data={'token': token})
     assert r.status_code == 200
 
+    headers['DPoP'] = dpop_key.proof(f'{BASE_RS}/data', 'GET')
     r = requests.get(f'{BASE_RS}/data', headers=headers)
     assert r.status_code == 403

--- a/tests/test_security_enforcements.py
+++ b/tests/test_security_enforcements.py
@@ -1,0 +1,50 @@
+import requests
+from tests.utils import generate_pkce_pair
+
+BASE_AUTH = 'http://localhost:5000'
+BASE_RS = 'http://localhost:6000'
+
+
+def test_invalid_code_verifier():
+    verifier, challenge = generate_pkce_pair()
+    r = requests.get(
+        f'{BASE_AUTH}/authorize',
+        params={
+            'user': 'alice',
+            'client_id': 'agent-client-id',
+            'scope': 'read:data',
+            'code_challenge': challenge,
+            'code_challenge_method': 'S256',
+        },
+    )
+    token = r.json()['delegation_token']
+    # send wrong verifier
+    r = requests.post(
+        f'{BASE_AUTH}/token',
+        data={'delegation_token': token, 'code_verifier': 'wrong'}
+    )
+    assert r.status_code == 403
+
+
+def test_missing_dpop_header(dpop_key):
+    verifier, challenge = generate_pkce_pair()
+    r = requests.get(
+        f'{BASE_AUTH}/authorize',
+        params={
+            'user': 'alice',
+            'client_id': 'agent-client-id',
+            'scope': 'read:data',
+            'code_challenge': challenge,
+            'code_challenge_method': 'S256',
+        },
+    )
+    token = r.json()['delegation_token']
+    r = requests.post(
+        f'{BASE_AUTH}/token',
+        data={'delegation_token': token, 'code_verifier': verifier}
+    )
+    access = r.json()['access_token']
+    headers = {'Authorization': f'Bearer {access}'}
+    r = requests.get(f'{BASE_RS}/data', headers=headers)
+    assert r.status_code == 401
+

--- a/tests/test_token_issuance.py
+++ b/tests/test_token_issuance.py
@@ -1,16 +1,23 @@
 import jwt
 import requests
 import auth_server
+from tests.utils import generate_pkce_pair
 
 JWT_SECRET = auth_server.JWT_SECRET
 BASE_URL = 'http://localhost:5000'
 
 def test_authorize_returns_delegation_token():
-    resp = requests.get(f'{BASE_URL}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data write:data'
-    })
+    verifier, challenge = generate_pkce_pair()
+    resp = requests.get(
+        f'{BASE_URL}/authorize',
+        params={
+            'user': 'alice',
+            'client_id': 'agent-client-id',
+            'scope': 'read:data write:data',
+            'code_challenge': challenge,
+            'code_challenge_method': 'S256'
+        }
+    )
     assert resp.status_code == 200
     token = resp.json()['delegation_token']
     decoded = jwt.decode(token, JWT_SECRET, algorithms=['HS256'])
@@ -20,14 +27,23 @@ def test_authorize_returns_delegation_token():
 
 def test_token_exchange_returns_access_token():
     # obtain delegation token first
-    r = requests.get(f'{BASE_URL}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data'
-    })
+    verifier, challenge = generate_pkce_pair()
+    r = requests.get(
+        f'{BASE_URL}/authorize',
+        params={
+            'user': 'alice',
+            'client_id': 'agent-client-id',
+            'scope': 'read:data',
+            'code_challenge': challenge,
+            'code_challenge_method': 'S256'
+        }
+    )
     delegation_token = r.json()['delegation_token']
 
-    r = requests.post(f'{BASE_URL}/token', data={'delegation_token': delegation_token})
+    r = requests.post(
+        f'{BASE_URL}/token',
+        data={'delegation_token': delegation_token, 'code_verifier': verifier}
+    )
     assert r.status_code == 200
     access_token = r.json()['access_token']
     decoded = jwt.decode(access_token, JWT_SECRET, algorithms=['HS256'])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,14 @@
 import threading
 import time
 from werkzeug.serving import make_server
+import secrets
+import hashlib
+import base64
+import json
+import uuid
+import jwt
+from jwt import algorithms
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 class ServerThread(threading.Thread):
     def __init__(self, app, host='localhost', port=0):
@@ -22,3 +30,31 @@ def start_server(app, port):
     # Wait briefly for server to start
     time.sleep(0.2)
     return server
+
+
+def generate_pkce_pair():
+    verifier = secrets.token_urlsafe(32)
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()
+    ).decode().rstrip("=")
+    return verifier, challenge
+
+
+class DPoPKey:
+    def __init__(self):
+        self.private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        self.public_jwk = json.loads(algorithms.RSAAlgorithm.to_jwk(self.private_key.public_key()))
+
+    def proof(self, url, method="GET"):
+        payload = {
+            "htu": url,
+            "htm": method,
+            "iat": int(time.time()),
+            "jti": str(uuid.uuid4()),
+        }
+        return jwt.encode(
+            payload,
+            self.private_key,
+            algorithm="RS256",
+            headers={"jwk": self.public_jwk, "typ": "dpop+jwt"},
+        )


### PR DESCRIPTION
## Summary
- require PKCE verifier/challenge during token issuance
- sign requests with DPoP proofs and validate them
- update AI agent example
- include cryptography dependency
- add tests for PKCE and DPoP behaviours

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8ab0137c8324896dd99a16d4fda7