### PR TITLE
Add config toggle for Keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ pip install Flask PyJWT requests
 Start each service in its own terminal:
 
 ### 1. Authorization Server
+Set `USE_KEYCLOAK=true` in the environment or edit `config.py` to enable
+Keycloak-based login. Without it, a simple in-memory user store is used.
 ```bash
 python auth_server.py
 ```

--- a/auth_server.py
+++ b/auth_server.py
@@ -1,7 +1,13 @@
 # === File: auth_server.py ===
-from flask import Flask, request, jsonify
+import secrets
+from urllib.parse import urlencode
+
+import requests
+from flask import Flask, request, jsonify, redirect
 from datetime import datetime, timedelta
 import jwt
+
+import config
 
 app = Flask(__name__)
 JWT_SECRET = 'jwt-signing-secret'
@@ -10,24 +16,95 @@ USERS = {"alice": "password123"}
 ACTIVE_TOKENS = []
 REVOKED_TOKENS = set()
 
+USE_KEYCLOAK = config.USE_KEYCLOAK
+
+KEYCLOAK_URL = config.KEYCLOAK_URL
+KEYCLOAK_REALM = config.KEYCLOAK_REALM
+KEYCLOAK_CLIENT_ID = config.KEYCLOAK_CLIENT_ID
+KEYCLOAK_CLIENT_SECRET = config.KEYCLOAK_CLIENT_SECRET
+REDIRECT_URI = config.REDIRECT_URI
+
+PENDING_AUTH = {}
+ID_TOKENS = {}
+
 @app.route('/authorize')
 def authorize():
-    user = request.args.get('user')
     client_id = request.args.get('client_id')
     scope = request.args.get('scope', '')
+    user = request.args.get('user')
 
-    if user not in USERS:
-        return "User not found", 403
     if client_id not in AGENTS:
         return "Agent not registered", 403
 
+    if USE_KEYCLOAK:
+        state = secrets.token_urlsafe(16)
+        PENDING_AUTH[state] = {
+            "client_id": client_id,
+            "scope": scope,
+        }
+
+        query = urlencode({
+            "client_id": KEYCLOAK_CLIENT_ID,
+            "response_type": "code",
+            "scope": "openid",
+            "redirect_uri": REDIRECT_URI,
+            "state": state,
+        })
+        return redirect(
+            f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/auth?{query}"
+        )
+    else:
+        if user not in USERS:
+            return "User not found", 403
+
+        delegation = {
+            "iss": "http://localhost:5000",
+            "sub": client_id,
+            "delegator": user,
+            "scope": scope.split(),
+            "exp": datetime.utcnow() + timedelta(minutes=10),
+            "iat": datetime.utcnow(),
+        }
+        delegation_token = jwt.encode(delegation, JWT_SECRET, algorithm="HS256")
+        return jsonify({"delegation_token": delegation_token})
+
+
+@app.route('/callback')
+def callback():
+    if not USE_KEYCLOAK:
+        return "Keycloak disabled", 400
+
+    code = request.args.get('code')
+    state = request.args.get('state')
+    if not code or state not in PENDING_AUTH:
+        return "Invalid callback", 400
+
+    pending = PENDING_AUTH.pop(state)
+    token_res = requests.post(
+        f"{KEYCLOAK_URL}/realms/{KEYCLOAK_REALM}/protocol/openid-connect/token",
+        data={
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": REDIRECT_URI,
+            "client_id": KEYCLOAK_CLIENT_ID,
+            "client_secret": KEYCLOAK_CLIENT_SECRET,
+        },
+    )
+    token_res.raise_for_status()
+    id_token = token_res.json().get("id_token")
+    if not id_token:
+        return "No id token", 400
+
+    claims = jwt.decode(id_token, options={"verify_signature": False})
+    ID_TOKENS[claims["sub"]] = id_token
+
     delegation = {
         "iss": "http://localhost:5000",
-        "sub": client_id,
-        "delegator": user,
-        "scope": scope.split(),
+        "sub": pending["client_id"],
+        "delegator": claims["sub"],
+        "scope": pending["scope"].split(),
         "exp": datetime.utcnow() + timedelta(minutes=10),
-        "iat": datetime.utcnow()
+        "iat": datetime.utcnow(),
     }
     delegation_token = jwt.encode(delegation, JWT_SECRET, algorithm="HS256")
     return jsonify({"delegation_token": delegation_token})
@@ -41,6 +118,9 @@ def token():
         return "Delegation token expired", 403
     except jwt.InvalidTokenError:
         return "Invalid delegation token", 403
+
+    if USE_KEYCLOAK and delegation["delegator"] not in ID_TOKENS:
+        return "User not authenticated", 403
 
     access_claim = {
         "iss": "http://localhost:5000",

--- a/config.py
+++ b/config.py
@@ -1,0 +1,10 @@
+import os
+
+# Flag controlling whether Keycloak is used for user authentication
+USE_KEYCLOAK = os.environ.get("USE_KEYCLOAK", "false").lower() == "true"
+
+KEYCLOAK_URL = os.environ.get("KEYCLOAK_URL", "http://localhost:8080")
+KEYCLOAK_REALM = os.environ.get("KEYCLOAK_REALM", "master")
+KEYCLOAK_CLIENT_ID = os.environ.get("KEYCLOAK_CLIENT_ID", "test-client")
+KEYCLOAK_CLIENT_SECRET = os.environ.get("KEYCLOAK_CLIENT_SECRET", "secret")
+REDIRECT_URI = os.environ.get("REDIRECT_URI", "http://localhost:5000/callback")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,7 @@ Flask==2.3.3
 PyJWT==2.8.0
 requests==2.32.2
 
+python-keycloak==5.5.1
+responses==0.25.7
+
 pytest==8.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,16 @@
 import os, sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import pytest
+os.environ["USE_KEYCLOAK"] = "true"
 import auth_server
 import resource_server
 from tests.utils import start_server
 
 @pytest.fixture(scope='session', autouse=True)
 def servers():
+    # enable keycloak integration for tests
+    auth_server.config.USE_KEYCLOAK = True
+    auth_server.USE_KEYCLOAK = True
     # start auth and resource servers for tests
     auth_srv = start_server(auth_server.app, port=5000)
     res_srv = start_server(resource_server.app, port=6000)
@@ -18,3 +22,5 @@ def servers():
 def reset_state():
     auth_server.ACTIVE_TOKENS.clear()
     auth_server.REVOKED_TOKENS.clear()
+    auth_server.PENDING_AUTH.clear()
+    auth_server.ID_TOKENS.clear()

--- a/tests/test_delegation_flow.py
+++ b/tests/test_delegation_flow.py
@@ -1,16 +1,34 @@
 import requests
+import responses
+import jwt
+import auth_server
 
 BASE_AUTH = 'http://localhost:5000'
 BASE_RS = 'http://localhost:6000'
 
+def _mock_idp(rsps):
+    id_token = jwt.encode({"sub": "alice"}, "id-secret", algorithm="HS256")
+    url = f"{auth_server.KEYCLOAK_URL}/realms/{auth_server.KEYCLOAK_REALM}/protocol/openid-connect/token"
+    rsps.add(rsps.POST, url, json={"id_token": id_token})
+    return id_token
+
+
+@responses.activate
 def test_full_delegation_flow():
-    r = requests.get(f'{BASE_AUTH}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data'
-    })
+    _mock_idp(responses)
+    responses.add_passthru(BASE_AUTH)
+    responses.add_passthru(BASE_RS)
+    r = requests.get(
+        f"{BASE_AUTH}/authorize",
+        params={"client_id": "agent-client-id", "scope": "read:data"},
+        allow_redirects=False,
+    )
+    assert r.status_code == 302
+    state = r.headers["Location"].split("state=")[1]
+
+    r = requests.get(f"{BASE_AUTH}/callback", params={"code": "fake", "state": state})
     assert r.status_code == 200
-    delegation = r.json()['delegation_token']
+    delegation = r.json()["delegation_token"]
 
     r = requests.post(f'{BASE_AUTH}/token', data={'delegation_token': delegation})
     assert r.status_code == 200

--- a/tests/test_revocation.py
+++ b/tests/test_revocation.py
@@ -1,17 +1,33 @@
 import requests
+import responses
+import jwt
+import auth_server
 
 BASE_AUTH = 'http://localhost:5000'
 BASE_RS = 'http://localhost:6000'
 
+def _mock_idp(rsps):
+    id_token = jwt.encode({"sub": "alice"}, "id-secret", algorithm="HS256")
+    url = f"{auth_server.KEYCLOAK_URL}/realms/{auth_server.KEYCLOAK_REALM}/protocol/openid-connect/token"
+    rsps.add(rsps.POST, url, json={"id_token": id_token})
+
+
 def _get_access_token():
-    r = requests.get(f'{BASE_AUTH}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data'
-    })
-    delegation = r.json()['delegation_token']
-    r = requests.post(f'{BASE_AUTH}/token', data={'delegation_token': delegation})
-    return r.json()['access_token']
+    with responses.RequestsMock() as rsps:
+        _mock_idp(rsps)
+        rsps.add_passthru(BASE_AUTH)
+        rsps.add_passthru(BASE_RS)
+        r = requests.get(
+            f"{BASE_AUTH}/authorize",
+            params={"client_id": "agent-client-id", "scope": "read:data"},
+            allow_redirects=False,
+        )
+        state = r.headers["Location"].split("state=")[1]
+        r = requests.get(f"{BASE_AUTH}/callback", params={"code": "fake", "state": state})
+        delegation = r.json()["delegation_token"]
+
+        r = requests.post(f"{BASE_AUTH}/token", data={"delegation_token": delegation})
+        return r.json()["access_token"]
 
 def test_revoked_token_rejected():
     token = _get_access_token()

--- a/tests/test_token_issuance.py
+++ b/tests/test_token_issuance.py
@@ -1,35 +1,58 @@
 import jwt
 import requests
+import responses
 import auth_server
 
 JWT_SECRET = auth_server.JWT_SECRET
 BASE_URL = 'http://localhost:5000'
 
+def _mock_idp(rsps, sub="alice"):
+    id_token = jwt.encode({"sub": sub}, "id-secret", algorithm="HS256")
+    url = (
+        f"{auth_server.KEYCLOAK_URL}/realms/{auth_server.KEYCLOAK_REALM}/protocol/openid-connect/token"
+    )
+    rsps.add(rsps.POST, url, json={"id_token": id_token})
+    return id_token
+
+
+@responses.activate
 def test_authorize_returns_delegation_token():
-    resp = requests.get(f'{BASE_URL}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data write:data'
-    })
+    _mock_idp(responses)
+    responses.add_passthru(BASE_URL)
+    resp = requests.get(
+        f"{BASE_URL}/authorize",
+        params={"client_id": "agent-client-id", "scope": "read:data write:data"},
+        allow_redirects=False,
+    )
+    assert resp.status_code == 302
+    state = resp.headers["Location"].split("state=")[1]
+
+    resp = requests.get(
+        f"{BASE_URL}/callback", params={"code": "fake", "state": state}
+    )
     assert resp.status_code == 200
-    token = resp.json()['delegation_token']
-    decoded = jwt.decode(token, JWT_SECRET, algorithms=['HS256'])
-    assert decoded['sub'] == 'agent-client-id'
-    assert decoded['delegator'] == 'alice'
+    token = resp.json()["delegation_token"]
+    decoded = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+    assert decoded["sub"] == "agent-client-id"
+    assert decoded["delegator"] == "alice"
 
 
+@responses.activate
 def test_token_exchange_returns_access_token():
-    # obtain delegation token first
-    r = requests.get(f'{BASE_URL}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data'
-    })
-    delegation_token = r.json()['delegation_token']
+    _mock_idp(responses)
+    responses.add_passthru(BASE_URL)
+    r = requests.get(
+        f"{BASE_URL}/authorize",
+        params={"client_id": "agent-client-id", "scope": "read:data"},
+        allow_redirects=False,
+    )
+    state = r.headers["Location"].split("state=")[1]
+    r = requests.get(f"{BASE_URL}/callback", params={"code": "fake", "state": state})
+    delegation_token = r.json()["delegation_token"]
 
-    r = requests.post(f'{BASE_URL}/token', data={'delegation_token': delegation_token})
+    r = requests.post(f"{BASE_URL}/token", data={"delegation_token": delegation_token})
     assert r.status_code == 200
-    access_token = r.json()['access_token']
-    decoded = jwt.decode(access_token, JWT_SECRET, algorithms=['HS256'])
-    assert decoded['sub'] == 'alice'
-    assert decoded['actor'] == 'agent-client-id'
+    access_token = r.json()["access_token"]
+    decoded = jwt.decode(access_token, JWT_SECRET, algorithms=["HS256"])
+    assert decoded["sub"] == "alice"
+    assert decoded["actor"] == "agent-client-id"


### PR DESCRIPTION
## Summary
- make Keycloak integration optional using `config.py`
- fall back to local auth when `USE_KEYCLOAK` is false
- update README instructions for the new setting
- ensure tests force Keycloak mode

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8aacb9c08324a581b1dde480a873