### PR TITLE
Add convenience script for local demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ pip install Flask PyJWT requests cryptography
 ## 🚀 Running the System
 
 Start each service in its own terminal:
+Alternatively, run `./run_local.sh` to set up a virtual environment and launch all components automatically.
 
 ### 1. Authorization Server
 ```bash

--- a/run_local.sh
+++ b/run_local.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# Create virtual environment if not exists
+if [ ! -d ".venv" ]; then
+    python3 -m venv .venv
+fi
+
+source .venv/bin/activate
+
+# Install required dependencies
+pip install -r requirements.txt
+
+# Start servers in background
+python auth_server.py &
+AUTH_PID=$!
+python resource_server.py &
+RS_PID=$!
+
+# Ensure servers are terminated on exit
+cleanup() {
+    kill $AUTH_PID $RS_PID
+    deactivate
+}
+trap cleanup EXIT
+
+# Give servers time to start
+sleep 1
+
+# Run the demo agent
+python ai_agent.py
+


### PR DESCRIPTION
## Summary
- add `run_local.sh` script to set up a venv, install dependencies and run the demo services
- mention the script in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a8855dd4083248919f101e8bdde5d