### PR TITLE
Add demo frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ python resource_server.py
 python ai_agent.py
 ```
 
+### 4. Demo Frontend
+```bash
+python demo_frontend.py
+```
+Visit `http://localhost:7000/` in your browser to see the protocol steps and results.
+
 ## ✅ Expected Flow
 
 - The AI agent requests a **delegation token** for a user (`alice`).

--- a/demo_frontend.py
+++ b/demo_frontend.py
@@ -1,0 +1,49 @@
+from flask import Flask, render_template_string
+import requests
+import json
+
+app = Flask(__name__)
+
+TEMPLATE = """<!doctype html>
+<html lang='en'>
+  <head>
+    <meta charset='utf-8'/>
+    <title>Delegation Protocol Demo</title>
+    <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css'>
+  </head>
+  <body class='container py-4'>
+    <h1 class='mb-4'>Delegation Protocol Demo</h1>
+    <h2 class='h5'>Step 1: Delegation Token</h2>
+    <pre class='bg-light p-3'>{{ delegation }}</pre>
+    <h2 class='h5'>Step 2: Access Token</h2>
+    <pre class='bg-light p-3'>{{ access }}</pre>
+    <h2 class='h5'>Step 3: Resource Response</h2>
+    <pre class='bg-light p-3'>{{ data }}</pre>
+  </body>
+</html>"""
+
+BASE_AUTH = 'http://localhost:5000'
+BASE_RS = 'http://localhost:6000'
+
+@app.route('/')
+def demo():
+    r = requests.get(f'{BASE_AUTH}/authorize', params={
+        'user': 'alice',
+        'client_id': 'agent-client-id',
+        'scope': 'read:data'
+    })
+    r.raise_for_status()
+    delegation = r.json()['delegation_token']
+
+    r = requests.post(f'{BASE_AUTH}/token', data={'delegation_token': delegation})
+    r.raise_for_status()
+    access = r.json()['access_token']
+
+    r = requests.get(f'{BASE_RS}/data', headers={'Authorization': f'Bearer {access}'})
+    r.raise_for_status()
+    data = json.dumps(r.json(), indent=2)
+
+    return render_template_string(TEMPLATE, delegation=delegation, access=access, data=data)
+
+if __name__ == '__main__':
+    app.run(port=7000)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -1,0 +1,12 @@
+import requests
+import demo_frontend
+from tests.utils import start_server
+
+
+def test_frontend_demo():
+    server = start_server(demo_frontend.app, port=7000)
+    resp = requests.get('http://localhost:7000/')
+    server.shutdown()
+    assert resp.status_code == 200
+    assert 'Delegation Protocol Demo' in resp.text
+    assert 'alice' in resp.text


### PR DESCRIPTION
## Summary
- create `demo_frontend.py` to render a Bootstrap page showing the delegation flow
- document running the demo frontend in the README
- add tests for the frontend demo

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa32da16483249b032425472b933a