### PR TITLE
Add dynamic protocol sequence diagram

### DIFF
--- a/demo_frontend.py
+++ b/demo_frontend.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template_string
+from flask import Flask, render_template_string, Response
 import requests
 import json
 
@@ -10,15 +10,27 @@ TEMPLATE = """<!doctype html>
     <meta charset='utf-8'/>
     <title>Delegation Protocol Demo</title>
     <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css'>
+    <script src='https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js'></script>
   </head>
   <body class='container py-4'>
     <h1 class='mb-4'>Delegation Protocol Demo</h1>
-    <h2 class='h5'>Step 1: Delegation Token</h2>
-    <pre class='bg-light p-3'>{{ delegation }}</pre>
-    <h2 class='h5'>Step 2: Access Token</h2>
-    <pre class='bg-light p-3'>{{ access }}</pre>
-    <h2 class='h5'>Step 3: Resource Response</h2>
-    <pre class='bg-light p-3'>{{ data }}</pre>
+    <div id='diagram'></div>
+    <pre id='log' class='bg-light p-3 mt-3'></pre>
+    <script>
+      mermaid.initialize({startOnLoad:false});
+      let diagram = '';
+      const container = document.getElementById('diagram');
+      const log = document.getElementById('log');
+      const evt = new EventSource('/flow');
+      evt.addEventListener('line', e => {
+        diagram += e.data + '\n';
+        container.innerHTML = '<div class="mermaid">'+diagram+'</div>';
+        mermaid.init(undefined, container);
+      });
+      evt.addEventListener('result', e => {
+        log.textContent += e.data + '\n';
+      });
+    </script>
   </body>
 </html>"""
 
@@ -27,23 +39,44 @@ BASE_RS = 'http://localhost:6000'
 
 @app.route('/')
 def demo():
-    r = requests.get(f'{BASE_AUTH}/authorize', params={
-        'user': 'alice',
-        'client_id': 'agent-client-id',
-        'scope': 'read:data'
-    })
-    r.raise_for_status()
-    delegation = r.json()['delegation_token']
+    return render_template_string(TEMPLATE)
 
-    r = requests.post(f'{BASE_AUTH}/token', data={'delegation_token': delegation})
-    r.raise_for_status()
-    access = r.json()['access_token']
 
-    r = requests.get(f'{BASE_RS}/data', headers={'Authorization': f'Bearer {access}'})
-    r.raise_for_status()
-    data = json.dumps(r.json(), indent=2)
+@app.route('/flow')
+def flow():
+    def generate():
+        yield 'event: line\n'
+        yield 'data: sequenceDiagram\\n    participant Browser\\n    participant AS\\n    participant RS\n\n'
 
-    return render_template_string(TEMPLATE, delegation=delegation, access=access, data=data)
+        r = requests.get(f"{BASE_AUTH}/authorize", params={
+            "user": "alice",
+            "client_id": "agent-client-id",
+            "scope": "read:data",
+        })
+        r.raise_for_status()
+        delegation = r.json()["delegation_token"]
+        yield 'event: line\n'
+        yield 'data: Browser->>AS: /authorize\n\n'
+        yield 'event: result\n'
+        yield f"data: {json.dumps({'delegation': delegation})}\n\n"
+
+        r = requests.post(f"{BASE_AUTH}/token", data={"delegation_token": delegation})
+        r.raise_for_status()
+        access = r.json()["access_token"]
+        yield 'event: line\n'
+        yield 'data: Browser->>AS: /token\n\n'
+        yield 'event: result\n'
+        yield f"data: {json.dumps({'access': access})}\n\n"
+
+        r = requests.get(f"{BASE_RS}/data", headers={"Authorization": f"Bearer {access}"})
+        r.raise_for_status()
+        body = r.json()
+        yield 'event: line\n'
+        yield 'data: Browser->>RS: /data\n\n'
+        yield 'event: result\n'
+        yield f"data: {json.dumps(body)}\n\n"
+
+    return Response(generate(), mimetype='text/event-stream')
 
 if __name__ == '__main__':
     app.run(port=7000)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -6,7 +6,9 @@ from tests.utils import start_server
 def test_frontend_demo():
     server = start_server(demo_frontend.app, port=7000)
     resp = requests.get('http://localhost:7000/')
+    flow = requests.get('http://localhost:7000/flow')
     server.shutdown()
     assert resp.status_code == 200
     assert 'Delegation Protocol Demo' in resp.text
-    assert 'alice' in resp.text
+    assert flow.status_code == 200
+    assert 'alice' in flow.text


### PR DESCRIPTION
## Summary
- update demo frontend to push protocol events via server-sent events
- render a live sequence diagram with Mermaid.js
- adjust frontend test to expect SSE data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa5a7ed3c83249821d898af986527