### PR TITLE
Add user registration endpoint and tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,13 @@ jobs:
       image: python:3.11
     env:
       AGENTS_FILE: /tmp/agents.json
+      USERS_FILE: /tmp/users.json
     steps:
       - uses: actions/checkout@v3
       - name: Initialize sample agent data
         run: |
           echo '{"agent-client-id": {"name": "CalendarAgent"}}' > "$AGENTS_FILE"
+          echo '{"alice": "password123"}' > "$USERS_FILE"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ curl -X POST -d "token=<access_token>" http://localhost:5000/revoke
 ```
 Subsequent attempts to use the token will be rejected.
 
+## 👥 User Registration
+The authorization server includes one default user (`alice`).
+Additional users can be added via a JSON POST request:
+```bash
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"username": "bob", "password": "secret"}' \
+     http://localhost:5000/register_user
+```
+After registering, the new username can be supplied as the `user` parameter when
+calling `/authorize`.
+
 ## 📂 File Structure
 ```
 .

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,12 @@ json.dump({"agent-client-id": {"name": "CalendarAgent"}}, temp_agents_file)
 temp_agents_file.close()
 os.environ["AGENTS_FILE"] = temp_agents_file.name
 
+# Temporary users file so tests can register and authenticate users
+temp_users_file = tempfile.NamedTemporaryFile(mode="w+", delete=False)
+json.dump({"alice": "password123"}, temp_users_file)
+temp_users_file.close()
+os.environ["USERS_FILE"] = temp_users_file.name
+
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 import pytest
@@ -26,6 +32,7 @@ def servers():
     res_srv.shutdown()
     auth_srv.shutdown()
     os.remove(temp_agents_file.name)
+    os.remove(temp_users_file.name)
 
 @pytest.fixture(autouse=True)
 def reset_state():
@@ -33,3 +40,4 @@ def reset_state():
     auth_server.REVOKED_TOKENS.clear()
     # reload agents from persistent file to ensure isolation
     auth_server.AGENTS = auth_server.load_agents()
+    auth_server.USERS = auth_server.load_users()

--- a/tests/test_user_registration.py
+++ b/tests/test_user_registration.py
@@ -1,0 +1,26 @@
+import requests
+
+BASE_URL = 'http://localhost:5000'
+
+
+def test_register_new_user():
+    resp = requests.post(f'{BASE_URL}/register_user', json={
+        'username': 'bob',
+        'password': 'secret'
+    })
+    assert resp.status_code == 201
+
+    r = requests.get(f'{BASE_URL}/authorize', params={
+        'user': 'bob',
+        'client_id': 'agent-client-id',
+        'scope': 'read:data'
+    })
+    assert r.status_code == 200
+
+
+def test_register_duplicate_user_fails():
+    resp = requests.post(f'{BASE_URL}/register_user', json={
+        'username': 'alice',
+        'password': 'password123'
+    })
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- implement `/register_user` endpoint in `auth_server.py`
- persist users in a new `users.json` file
- create tests covering user registration
- reset users state during tests
- extend GitHub actions workflow to provide a users file
- document registration steps in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa6b2b41c8324846adc09666c49e4