### PR TITLE
Add interactive demo route

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ python ai_agent.py
 ```bash
 python demo_frontend.py
 ```
-Visit `http://localhost:7000/` in your browser to see the protocol steps and results.
+Visit `http://localhost:7000/` in your browser and click **Start Demo** to trigger the
+authorization, token exchange, and resource calls. The resulting JSON will appear on the page.
 
 ## ✅ Expected Flow
 

--- a/demo_frontend.py
+++ b/demo_frontend.py
@@ -1,6 +1,5 @@
-from flask import Flask, render_template_string, Response
+from flask import Flask, render_template_string, jsonify
 import requests
-import json
 
 app = Flask(__name__)
 
@@ -10,26 +9,20 @@ TEMPLATE = """<!doctype html>
     <meta charset='utf-8'/>
     <title>Delegation Protocol Demo</title>
     <link rel='stylesheet' href='https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css'>
-    <script src='https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js'></script>
   </head>
   <body class='container py-4'>
     <h1 class='mb-4'>Delegation Protocol Demo</h1>
-    <div id='diagram'></div>
-    <pre id='log' class='bg-light p-3 mt-3'></pre>
+    <button id='start' class='btn btn-primary mb-3'>Start Demo</button>
+    <pre id='log' class='bg-light p-3'></pre>
     <script>
-      mermaid.initialize({startOnLoad:false});
-      let diagram = '';
-      const container = document.getElementById('diagram');
-      const log = document.getElementById('log');
-      const evt = new EventSource('/flow');
-      evt.addEventListener('line', e => {
-        diagram += e.data + '\n';
-        container.innerHTML = '<div class="mermaid">'+diagram+'</div>';
-        mermaid.init(undefined, container);
-      });
-      evt.addEventListener('result', e => {
-        log.textContent += e.data + '\n';
-      });
+      function runDemo() {
+        fetch('/run')
+          .then(r => r.json())
+          .then(data => {
+            document.getElementById('log').textContent = JSON.stringify(data, null, 2);
+          });
+      }
+      document.getElementById('start').addEventListener('click', runDemo);
     </script>
   </body>
 </html>"""
@@ -42,41 +35,25 @@ def demo():
     return render_template_string(TEMPLATE)
 
 
-@app.route('/flow')
-def flow():
-    def generate():
-        yield 'event: line\n'
-        yield 'data: sequenceDiagram\\n    participant Browser\\n    participant AS\\n    participant RS\n\n'
+@app.route('/run')
+def run_flow():
+    r = requests.get(f"{BASE_AUTH}/authorize", params={
+        "user": "alice",
+        "client_id": "agent-client-id",
+        "scope": "read:data",
+    })
+    r.raise_for_status()
+    delegation = r.json()["delegation_token"]
 
-        r = requests.get(f"{BASE_AUTH}/authorize", params={
-            "user": "alice",
-            "client_id": "agent-client-id",
-            "scope": "read:data",
-        })
-        r.raise_for_status()
-        delegation = r.json()["delegation_token"]
-        yield 'event: line\n'
-        yield 'data: Browser->>AS: /authorize\n\n'
-        yield 'event: result\n'
-        yield f"data: {json.dumps({'delegation': delegation})}\n\n"
+    r = requests.post(f"{BASE_AUTH}/token", data={"delegation_token": delegation})
+    r.raise_for_status()
+    access = r.json()["access_token"]
 
-        r = requests.post(f"{BASE_AUTH}/token", data={"delegation_token": delegation})
-        r.raise_for_status()
-        access = r.json()["access_token"]
-        yield 'event: line\n'
-        yield 'data: Browser->>AS: /token\n\n'
-        yield 'event: result\n'
-        yield f"data: {json.dumps({'access': access})}\n\n"
+    r = requests.get(f"{BASE_RS}/data", headers={"Authorization": f"Bearer {access}"})
+    r.raise_for_status()
+    body = r.json()
 
-        r = requests.get(f"{BASE_RS}/data", headers={"Authorization": f"Bearer {access}"})
-        r.raise_for_status()
-        body = r.json()
-        yield 'event: line\n'
-        yield 'data: Browser->>RS: /data\n\n'
-        yield 'event: result\n'
-        yield f"data: {json.dumps(body)}\n\n"
-
-    return Response(generate(), mimetype='text/event-stream')
+    return jsonify({"delegation": delegation, "access": access, "data": body})
 
 if __name__ == '__main__':
     app.run(port=7000)

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -6,9 +6,9 @@ from tests.utils import start_server
 def test_frontend_demo():
     server = start_server(demo_frontend.app, port=7000)
     resp = requests.get('http://localhost:7000/')
-    flow = requests.get('http://localhost:7000/flow')
+    run = requests.get('http://localhost:7000/run')
     server.shutdown()
     assert resp.status_code == 200
-    assert 'Delegation Protocol Demo' in resp.text
-    assert flow.status_code == 200
-    assert 'alice' in flow.text
+    assert 'Start Demo' in resp.text
+    assert run.status_code == 200
+    assert run.json()['data']['user'] == 'alice'


### PR DESCRIPTION
## Summary
- simplify demo frontend with a **Start Demo** button
- expose `/run` route that performs the auth/token/resource flow
- update frontend tests to use the new route
- document updated demo instructions in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa90f4eb083248ba2e93556d86517