### PR TITLE
Add Docker build for frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ docker run --rm -p 5000:5000 -p 6000:6000 delegation-demo
 
 The container starts both servers and executes the demo agent.
 
+To build the production React UI, use the Dockerfile in `frontend/`:
+
+```bash
+cd frontend
+docker build -t delegation-frontend \
+  --build-arg VITE_API_BASE_URL=http://localhost:5000 .
+docker run --rm -p 8080:80 delegation-frontend
+```
+
+Set `VITE_API_BASE_URL` to the URL of the Python backend so the frontend can
+communicate with the API. A sample `docker-compose.yml` is provided to run all
+services together.
+
+```bash
+docker-compose up --build
+```
+
 Start each service in its own terminal:
 Alternatively, run `./run_local.sh` to set up a virtual environment and launch all components automatically.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,27 @@
+version: "3"
+services:
+  auth_server:
+    build: .
+    command: python auth_server.py
+    ports:
+      - "5000:5000"
+
+  resource_server:
+    build: .
+    command: python resource_server.py
+    ports:
+      - "6000:6000"
+    depends_on:
+      - auth_server
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        VITE_API_BASE_URL: http://auth_server:5000
+    ports:
+      - "8080:80"
+    depends_on:
+      - auth_server
+      - resource_server
+

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+ARG VITE_API_BASE_URL
+ENV VITE_API_BASE_URL=${VITE_API_BASE_URL}
+RUN npm run build
+
+FROM nginx:alpine
+COPY --from=build /app/dist /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,0 +1,14 @@
+import { vi } from 'vitest';
+import { fetchJSON, BASE_URL } from '../services/api';
+
+describe('fetchJSON', () => {
+  it('prefixes requests with BASE_URL', async () => {
+    const mockResponse = { ok: true, json: () => Promise.resolve({}) } as Response;
+    const fetchSpy = vi.fn().mockResolvedValue(mockResponse);
+    // @ts-ignore
+    global.fetch = fetchSpy;
+    await fetchJSON('/demo');
+    expect(fetchSpy).toHaveBeenCalledWith(BASE_URL + '/demo', undefined);
+  });
+});
+

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,4 +1,4 @@
-const BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+export const BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
 
 export async function fetchJSON<T>(url: string, options?: RequestInit): Promise<T> {
   const res = await fetch(BASE_URL + url, options);


### PR DESCRIPTION
## Summary
- dockerize React frontend with Vite
- allow running all services via docker-compose
- document frontend container build and compose usage
- expose BASE_URL constant in API and test it

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac7b6c43883248f078982f619a65f