### PR TITLE
Add frontend tests for docs, dashboard and API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,9 +12,12 @@ jobs:
       USERS_FILE: /tmp/users.json
     steps:
       - uses: actions/checkout@v3
-      - name: Install Node
-        run: |
-          apt-get update && apt-get install -y nodejs npm
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
       - name: Initialize sample agent data
         run: |
           echo '{"agent-client-id": {"name": "CalendarAgent"}}' > "$AGENTS_FILE"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,7 +33,8 @@
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.30.1",
         "vite": "^6.3.5",
-        "vitest": "^3.2.3"
+        "vitest": "^3.2.3",
+        "whatwg-fetch": "^3.6.2"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6779,6 +6780,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.20",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
+      "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/whatwg-mimetype": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
-    "vitest": "^3.2.3"
+    "vitest": "^3.2.3",
+    "whatwg-fetch": "^3.6.2"
   }
 }

--- a/frontend/src/__tests__/Dashboard.test.tsx
+++ b/frontend/src/__tests__/Dashboard.test.tsx
@@ -1,0 +1,17 @@
+import { vi } from "vitest";
+import { render, screen } from '@testing-library/react';
+import Dashboard from '../pages/Dashboard';
+import * as api from '../services/api';
+
+vi.mock('../services/api');
+
+const delegations = [{ id: '1', agent: 'agent1', status: 'pending' }];
+
+(api.getDelegations as any).mockResolvedValue(delegations);
+
+describe('Dashboard', () => {
+  it('renders pending delegations', async () => {
+    render(<Dashboard />);
+    await screen.findByText('agent1 - pending');
+  });
+});

--- a/frontend/src/__tests__/Docs.test.tsx
+++ b/frontend/src/__tests__/Docs.test.tsx
@@ -1,0 +1,14 @@
+import { vi } from "vitest";
+import { render, screen } from '@testing-library/react';
+import Docs from '../pages/Docs';
+
+describe('Docs', () => {
+  it('displays markdown from docs.md', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({
+      text: () => Promise.resolve('# Hello')
+    })) as any);
+    render(<Docs />);
+    await screen.findByText('Hello');
+    vi.restoreAllMocks();
+  });
+});

--- a/frontend/src/__tests__/api.test.ts
+++ b/frontend/src/__tests__/api.test.ts
@@ -1,0 +1,25 @@
+import { vi } from 'vitest';
+
+describe('fetchJSON', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('appends base url', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.test');
+    const { fetchJSON } = await import('../services/api');
+    (fetch as any).mockResolvedValue({ ok: true, json: () => Promise.resolve({}) });
+    await fetchJSON('/foo');
+    expect(fetch).toHaveBeenCalledWith('https://api.test/foo', undefined);
+    vi.unstubAllEnvs();
+  });
+
+  it('throws on error response', async () => {
+    const { fetchJSON } = await import('../services/api');
+    (fetch as any).mockResolvedValue({ ok: false, text: () => Promise.resolve('err') });
+    await expect(fetchJSON('/bad')).rejects.toThrow('err');
+  });
+});

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,2 @@
+import "whatwg-fetch";
 import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary
- add vitest tests for dashboard pending delegations
- add docs page test to check markdown fetch
- add tests for api.ts to ensure URL handling and errors
- polyfill `fetch` via `whatwg-fetch`
- install `whatwg-fetch` dev dependency
- run tests in GitHub Actions using setup-node

## Testing
- `npm test`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac7c27af88324a76092ca0bdf8d2a