### PR TITLE
Add Playwright testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
           node-version: 20
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
       - name: Initialize sample agent data
         run: |
           echo '{"agent-client-id": {"name": "CalendarAgent"}}' > "$AGENTS_FILE"
@@ -29,5 +31,11 @@ jobs:
       - name: Run frontend tests
         run: |
           cd frontend && npm test
+      - name: Build frontend
+        run: |
+          cd frontend && npm run build
+      - name: Run e2e tests
+        run: |
+          cd frontend && npm run test:e2e
       - name: Run python tests
         run: pytest -v

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -52,3 +52,19 @@ export default tseslint.config({
   },
 })
 ```
+
+## Running Playwright tests
+
+Install dependencies and browsers:
+
+```bash
+npm install
+npx playwright install
+```
+
+Run the tests:
+
+```bash
+npm run test:e2e
+```
+

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@playwright/test": "^1.53.1",
         "@tailwindcss/cli": "^4.1.10",
         "@tailwindcss/postcss": "^4.1.10",
         "@testing-library/jest-dom": "^6.6.3",
@@ -1569,6 +1570,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.1.tgz",
+      "integrity": "sha512-Z4c23LHV0muZ8hfv4jw6HngPJkbbtZxTkxPNIg7cJcTc9C28N/p2q7g3JZS2SiKBBHJ3uM1dgDye66bB7LEk5w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remix-run/router": {
@@ -5568,6 +5585,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.1.tgz",
+      "integrity": "sha512-LJ13YLr/ocweuwxyGf1XNFWIU4M2zUSo149Qbp+A4cpwDjsxRPj7k6H25LBrEHiEwxvRbD8HdwvQmRMSvquhYw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.1.tgz",
+      "integrity": "sha512-Z46Oq7tLAyT0lGoFx4DOuB1IA9D1TPj0QkYxpPVUnGDqHHvDpCftu1J2hM2PiWsNMoZh8+LQaarAWcDfPBc6zg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^19.1.0",
@@ -38,6 +39,7 @@
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5",
     "vitest": "^3.2.3",
-    "whatwg-fetch": "^3.6.2"
+    "whatwg-fetch": "^3.6.2",
+    "@playwright/test": "^1.53.1"
   }
 }

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from '@playwright/test';
+export default defineConfig({
+  webServer: {
+    command: 'npm run preview',
+    port: 4173,
+  },
+  testDir: 'tests/e2e',
+});

--- a/frontend/tests/e2e/home.spec.ts
+++ b/frontend/tests/e2e/home.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('landing page has Start Demo text', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByText('Start Demo')).toBeVisible();
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    setupFiles: './vitest.setup.ts'
+    setupFiles: './vitest.setup.ts',
+    exclude: ['tests/e2e/**', 'node_modules/**']
   }
 })

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pytest==8.2.0
 
 # Frontend dependencies managed via npm
 # react, react-dom, react-router-dom, react-markdown
+# E2E tests use Playwright via npm (@playwright/test)


### PR DESCRIPTION
## Summary
- add Playwright test runner and config
- document how to run Playwright tests
- ignore E2E tests from vitest
- update test workflow with Playwright steps

## Testing
- `npm test`
- `npm run build`
- `npm run test:e2e` *(fails: Start Demo text not found)*
- `pytest -v`


------
https://chatgpt.com/codex/tasks/task_e_685334e65738832494a7fa3890f336c3